### PR TITLE
queue_declare now returns also the queue name as it should according …

### DIFF
--- a/QUEUES.md
+++ b/QUEUES.md
@@ -28,7 +28,7 @@ Attaching to an existing queue also returns the number of pending messages and t
 
 ````julia
 QUEUE1 = "MyQueue"
-success, message_count, consumer_count = queue_declare(chan1, QUEUE1)
+success, queue_name, message_count, consumer_count = queue_declare(chan1, QUEUE1)
 success || println("error!")
 
 # operate with the queue
@@ -64,3 +64,4 @@ else
     println("error!")
 end
 ````
+

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -699,7 +699,7 @@ function queue_declare(chan::MessageChannel, name::String;
         passive::Bool=false, durable::Bool=false, exclusive::Bool=false, auto_delete::Bool=false,
         nowait::Bool=false, timeout::Int=DEFAULT_TIMEOUT,
         arguments::Dict{String,Any}=Dict{String,Any}())
-    _wait_resp(chan, (true, TAMQPMessageCount(0), Int32(0)), nowait, on_queue_declare_ok, :Queue, :DeclareOk, (false, TAMQPMessageCount(0), Int32(0)), timeout) do
+    _wait_resp(chan, (true, "", TAMQPMessageCount(0), Int32(0)), nowait, on_queue_declare_ok, :Queue, :DeclareOk, (false,"", TAMQPMessageCount(0), Int32(0)), timeout) do
         send_queue_declare(chan, name, passive, durable, exclusive, auto_delete, nowait, arguments)
     end
 end
@@ -1096,7 +1096,7 @@ function on_queue_declare_ok(chan::MessageChannel, m::TAMQPMethodFrame, ctx)
         name = convert(String, m.payload.fields[1].second)
         msg_count = m.payload.fields[2].second
         consumer_count = m.payload.fields[3].second
-        put!(ctx, (true, msg_count, consumer_count))
+        put!(ctx, (true, name, msg_count, consumer_count))
     end
     handle(chan, :Queue, :DeclareOk)
     nothing
@@ -1214,3 +1214,5 @@ on_confirm_select_ok(chan::MessageChannel, m::TAMQPMethodFrame, ctx) = _on_ack(c
 # ----------------------------------------
 # send and recv for methods end
 # ----------------------------------------
+
+

--- a/test/test_coverage.jl
+++ b/test/test_coverage.jl
@@ -38,7 +38,7 @@ function runtests(;virtualhost="/", host="localhost", port=AMQPClient.AMQP_DEFAU
 
     # create and bind queues
     testlog("creating queues...")
-    success, message_count, consumer_count = queue_declare(chan1, QUEUE1)
+    success, queue_name, message_count, consumer_count = queue_declare(chan1, QUEUE1)
     @test success
     @test message_count == 0
     @test consumer_count == 0
@@ -204,3 +204,4 @@ function test_types()
 end
 
 end # module AMQPTestCoverage
+

--- a/test/test_rpc.jl
+++ b/test/test_rpc.jl
@@ -28,7 +28,7 @@ function test_rpc_client(;virtualhost="/", host="localhost", port=AMQPClient.AMQ
     reply_queue_id += 1
     queue_name = QUEUE_RPC * "_" * string(reply_queue_id) * "_" * string(getpid())
     testlog("client creating queue " * queue_name * "...")
-    success, message_count, consumer_count = queue_declare(chan1, queue_name; exclusive=true)
+    success, queue_name, message_count, consumer_count = queue_declare(chan1, queue_name; exclusive=true)
 
     testlog("client testing rpc...")
     rpc_reply_count = 0
@@ -182,3 +182,4 @@ function runtests()
     testlog("done")
 end
 end # module AMQPTestRPC
+

--- a/test/test_throughput.jl
+++ b/test/test_throughput.jl
@@ -27,7 +27,7 @@ function setup(;virtualhost="/", host="localhost", port=AMQPClient.AMQP_DEFAULT_
 
     # create and bind queues
     testlog("creating queues...")
-    success, message_count, consumer_count = queue_declare(chan1, QUEUE1)
+    success, name, message_count, consumer_count = queue_declare(chan1, QUEUE1)
     @test success
     @test message_count == 0
 


### PR DESCRIPTION
…to the function documentation

I needed this to obtain the auto generated queue name. Now it is possible to do the following
```
julia> res = queue_declare(chan1,"";exclusive=true)
(true, "amq.gen-_P2yvrTGqpYCOJJ0QXFOYg", 0, 0)

```
Before, you could not get the second entry of the above 4-tuple.