### PR TITLE
check for stale connection while framing/chunking message to send

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+on:
+  push:
+    branches: [master]
+    tags: ["*"]
+  pull_request:
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - nightly
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    services:
+      rabbitmq:
+        image: rabbitmq:3-management
+        ports:
+          - 5672:5672
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "79c8b4cd-a41a-55fa-907c-fab5288e1383"
 keywords = ["amqpclient", "rabbitmq", "amqp", "amqp-client", "message-queue"]
 license = "MIT"
 desc = "A Julia AMQP (Advanced Message Queuing Protocol) / RabbitMQ Client."
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AMQPClient
 
-[![Build Status](https://travis-ci.org/JuliaComputing/AMQPClient.jl.svg?branch=master)](https://travis-ci.org/JuliaComputing/AMQPClient.jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaComputing/AMQPClient.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaComputing/AMQPClient.jl?branch=master)
+[![Build Status](https://github.com/JuliaComputing/AMQPClient.jl/workflows/CI/badge.svg)](https://github.com/JuliaComputing/AMQPClient.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![codecov.io](http://codecov.io/github/JuliaComputing/AMQPClient.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaComputing/AMQPClient.jl?branch=master)
 
 A Julia [AMQP (Advanced Message Queuing Protocol)](http://www.amqp.org/) Client.
 


### PR DESCRIPTION
This fixes a condition where sending a message on a stale connection can potentially get into an infinite loop while chunking a large message.