### PR TITLE
allow using tcp keepalives instead of heartbeats

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,25 +1,63 @@
 using AMQPClient
+using Test
 
 include("test_coverage.jl")
 include("test_throughput.jl")
 include("test_rpc.jl")
 
-AMQPTestCoverage.runtests()
-AMQPTestThroughput.runtests()
-AMQPTestRPC.runtests()
+@testset "AMQPClient" begin
+    @testset "AMQP" begin
+        @testset "Functionality" begin
+            for keepalive in [true, false]
+                for heartbeat in (true, false)
+                    @testset "keepalive=$keepalive,heartbeat=$heartbeat" begin
+                        AMQPTestCoverage.runtests(; keepalive=keepalive, heartbeat=heartbeat)
+                    end
+                end
+            end
+        end
+        # @testset "Throughput" begin
+        #     AMQPTestThroughput.runtests()
+        # end
+        # @testset "RPC" begin
+        #     AMQPTestRPC.runtests()
+        # end
+    end
 
-if length(ARGS) > 0
-    amqps_host = ARGS[1]
-    virtualhost = ARGS[2]
-    port = AMQPClient.AMQPS_DEFAULT_PORT
+    if length(ARGS) > 0
+        @testset "AMQPS" begin
+            amqps_host = ARGS[1]
+            virtualhost = ARGS[2]
+            port = AMQPClient.AMQPS_DEFAULT_PORT
 
-    login = ENV["AMQPPLAIN_LOGIN"]
-    password = ENV["AMQPPLAIN_PASSWORD"]
-    auth_params = Dict{String,Any}("MECHANISM"=>"AMQPLAIN", "LOGIN"=>login, "PASSWORD"=>password)
+            login = ENV["AMQPPLAIN_LOGIN"]
+            password = ENV["AMQPPLAIN_PASSWORD"]
+            auth_params = Dict{String,Any}("MECHANISM"=>"AMQPLAIN", "LOGIN"=>login, "PASSWORD"=>password)
 
-    AMQPTestCoverage.runtests(; host=amqps_host, port=AMQPClient.AMQPS_DEFAULT_PORT, virtualhost=virtualhost, amqps=amqps_configure(), auth_params=auth_params)
-    AMQPTestThroughput.runtests(; host=amqps_host, port=AMQPClient.AMQPS_DEFAULT_PORT, tls=true)
-    AMQPTestRPC.runtests(; host=amqps_host, port=AMQPClient.AMQPS_DEFAULT_PORT, amqps=amqps_configure())
+            @testset "Functionality" begin
+                for keepalive in [true, false]
+                    for heartbeat in (true, false)
+                        @testset "keepalive=$keepalive,heartbeat=$heartbeat" begin
+                            AMQPTestCoverage.runtests(;
+                                host=amqps_host,
+                                port=AMQPClient.AMQPS_DEFAULT_PORT,
+                                virtualhost=virtualhost,
+                                amqps=amqps_configure(),
+                                auth_params=auth_params,
+                                keepalive=keepalive,
+                                heartbeat=heartbeat)
+                        end
+                    end
+                end
+            end
+            @testset "Throughput" begin
+                AMQPTestThroughput.runtests(; host=amqps_host, port=AMQPClient.AMQPS_DEFAULT_PORT, tls=true)
+            end
+            @testset "RPC" begin
+                AMQPTestRPC.runtests(; host=amqps_host, port=AMQPClient.AMQPS_DEFAULT_PORT, amqps=amqps_configure())
+            end
+        end
+    end
 end
 
 exit(0)


### PR DESCRIPTION
AMQP allows heartbeats to be disabled completely, provided the server allows that.
But it is essential to have an alternative to detect network disconnections and stale
connections. In this PR, we switch on TCP keepalives on the connection (optional but
enabled by default) and allow heartbeats to be switched off. Heartbeats are still
enabled by default though.

The `connection` method has these new parameters to allow that:

```julia
connection(;
    heartbeat = true,
    keepalive = DEFAULT_KEEPALIVE_SECS,
)
```

- `heartbeat`: `true` to enable heartbeat, `false` to disable. Can also be set to a positive integer,
    in which case it is the heartbeat interval in seconds. Defaults to `true`. If `false`, ensure
    `keepalive` is enabled to detect dead connections. This parameter is negotiated with the server.
- `keepalive`: `true` to enable TCP keepalives, `false` to disable. Can also be set to a positive integer,
    in which case it is the keepalive interval in seconds. Defaults to `DEFAULT_KEEPALIVE_SECS`.