### PR TITLE
Handle empty message

### DIFF
--- a/src/buffered_socket.jl
+++ b/src/buffered_socket.jl
@@ -46,7 +46,7 @@ function fill_in(bio::BufferedTLSSocket, atleast::Int)
         while (atleast > avail) && isopen(bio.sock)
             bytes_read = isreadable(bio.sock) ? readbytes!(bio.sock, bio.readbuff; all=false) : 0
             if bytes_read > 0
-                avail += Base.write_sub(bio.in, bio.readbuff, 1, bytes_read)
+                avail += Base.write(bio.in, first(bio.readbuff, bytes_read))
             else
                 MbedTLS.wait_for_decrypted_data(bio.sock)
             end


### PR DESCRIPTION
Fixes https://github.com/JuliaComputing/AMQPClient.jl/issues/53

The problem is that the check for putting a completed message in the `recvq` was only done in the function that handles `BodyFrame`s but no body frame is sent when the message is empty. So I added a check in the processing of `HeaderFrame` to handle the empty case.

Edit: Sorry about the unnecessary commit, I merged thge old PR into my own fork before you pulled into master. I can recreate the PR if you want.