### PR TITLE
fix network byte ordering of field table

### DIFF
--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -51,10 +51,16 @@ function read(io::IO, ::Type{TAMQPFieldValue})
     c = read(io, Char)
     v = read(io, FieldValueIndicatorMap[c])
     T = FieldValueIndicatorMap[c]
+    if T <: Integer
+        v = ntoh(v)
+    end
     TAMQPFieldValue{T}(c, v)
 end
 
-write(io::IO, fv::TAMQPFieldValue) = write(io, fv.typ, fv.fld)
+function write(io::IO, fv::TAMQPFieldValue)
+    v = isa(fv.fld, Integer) ? hton(fv.fld) : fv.fld
+    write(io, fv.typ, v)
+end
 
 read(io::IO, ::Type{TAMQPFieldValuePair}) = TAMQPFieldValuePair(read(io, TAMQPFieldName), read(io, TAMQPFieldValue))
 


### PR DESCRIPTION
Integer fields in a field table should be transmitted with network byte ordering. This fixes read and write of field tables to enforce that.

fixes #57